### PR TITLE
Fixed restore backup ajax request triggering OWASP mod_security rules

### DIFF
--- a/admin.php
+++ b/admin.php
@@ -972,21 +972,21 @@ class UpdraftPlus_Admin {
 
 			echo json_encode($this->fetch_log($_REQUEST['backup_nonce']));
 
-		} elseif (isset($_GET['subaction']) && 'restore_alldownloaded' == $_GET['subaction'] && isset($_GET['restoreopts']) && isset($_GET['timestamp'])) {
+		} elseif (isset($_REQUEST['subaction']) && 'restore_alldownloaded' == $_REQUEST['subaction'] && isset($_REQUEST['restoreopts']) && isset($_REQUEST['timestamp'])) {
 
 			$backups = $updraftplus->get_backup_history();
 			$updraft_dir = $updraftplus->backups_dir_location();
 
-			$timestamp = (int)$_GET['timestamp'];
+			$timestamp = (int)$_REQUEST['timestamp'];
 			if (!isset($backups[$timestamp])) {
 				echo json_encode(array('m' => '', 'w' => '', 'e' => __('No such backup set exists', 'updraftplus')));
 				die;
 			}
 
 			$mess = array();
-			parse_str($_GET['restoreopts'], $res);
+			parse_str($_REQUEST['restoreopts'], $res);
 
-			if (isset($res['updraft_restore'])) {
+			if (isset($res['updraft_restore']) && is_array($res['updraft_restore']) && count($res['updraft_restore']) > 0) {
 
 				set_error_handler(array($this, 'get_php_errors'), E_ALL & ~E_STRICT);
 

--- a/includes/updraft-admin-ui.js
+++ b/includes/updraft-admin-ui.js
@@ -580,7 +580,7 @@ function updraft_restorer_checkstage2(doalert) {
 	}
 	// Allow pressing 'Restore' to proceed
 	jQuery('#updraft-restore-modal-stage2a').html(updraftlion.processing);
-	jQuery.get(ajaxurl, {
+	jQuery.post(ajaxurl, {
 		action: 'updraft_ajax',
 		subaction: 'restore_alldownloaded', 
 		nonce: updraft_credentialtest_nonce,


### PR DESCRIPTION
Ajax request 'restore_alldownloaded' triggered several mod_security rules. These rules are pretty agressive and have been reported to the OWASP team for review yet it was easy to fix on the updraft side.

Instead of sending all form data using multiple encoded GET request, all data is being sent using a POST request. This prevents mod_security from triggering false-positives.
